### PR TITLE
Search by channel + Command line interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ To use this script you will need to create a project with access to the YouTube 
  - Click 'Enable APIs and services' and select YouTube Data API v3
  - On the 'Credentials' page for your new project, create an API key. You don't need to mke an OAuth Client ID.
  - Open ./auth/auth-template.py in a text editor, fill in your key values, and save the file as 'auth.py'
+ - Install Google API python client: 
+ 	`pip install --upgrade google-api-python-client google-auth-httplib2 google-auth-oauthlib`
 
 That's it - it should run. 
 

--- a/api.py
+++ b/api.py
@@ -37,7 +37,7 @@ class YoutubeClient:
         self.client = googleapiclient.discovery.build(
             api_service_name, api_version, developerKey=developer_key)
 
-    def _search(self, request):
+    def _search(self, request, limit=math.inf):
         ids = []
 
         response = request.execute()
@@ -86,7 +86,7 @@ class YoutubeClient:
             type='video'
         )
 
-        return self._search(request)
+        return self._search(request, limit=limit, )
 
 
     def search_by_keyword(self, query, limit=math.inf,
@@ -119,7 +119,7 @@ class YoutubeClient:
             type='video'
         )
         
-        return self._search(request)
+        return self._search(request, limit=limit)
         
 
     def get_videos(self, query, get_stats=True):

--- a/api.py
+++ b/api.py
@@ -37,7 +37,7 @@ class YoutubeClient:
         self.client = googleapiclient.discovery.build(
             api_service_name, api_version, developerKey=developer_key)
 
-    def _search(self, request, limit=math.inf):
+    def _search(self, request, limit=math.inf, query_name=None):
         ids = []
 
         response = request.execute()
@@ -64,7 +64,7 @@ class YoutubeClient:
                         print("403 on video - likely due to be rate limits.")
                         raise e
                 except KeyError:
-                    print('Found all videos for search term {}'.format(query))
+                    print('Found all videos for search {}'.format(query_name if query_name else request.uri))
                     break
         return ids
 
@@ -86,7 +86,7 @@ class YoutubeClient:
             type='video'
         )
 
-        return self._search(request, limit=limit, )
+        return self._search(request, limit=limit, query_name=channel_id)
 
 
     def search_by_keyword(self, query, limit=math.inf,
@@ -119,7 +119,7 @@ class YoutubeClient:
             type='video'
         )
         
-        return self._search(request, limit=limit)
+        return self._search(request, limit=limit, query_name=query)
         
 
     def get_videos(self, query, get_stats=True):
@@ -221,8 +221,7 @@ class YoutubeClient:
                         print("403 on user - likely due to be rate limits?")
                         raise e
                 except KeyError:
-                    print('Found all channels for user {}'
-                          .format(username))
+                    print('Found all channels for user {}'.format(username))
                     break
 
         return channels

--- a/example.py
+++ b/example.py
@@ -1,4 +1,4 @@
-from main import *
+from api import *
 from auth import auth
 import os
 from googleapiclient.errors import HttpError

--- a/yt-comments.py
+++ b/yt-comments.py
@@ -75,6 +75,8 @@ def convert_users_to_channels(args):
             if not is_link(link_or_id) or is_user(link_or_id):
                 user_id = id_from_link_or_id(link_or_id)
                 channels = client.get_user_channels(user_id, limit=args.limit)
+                if not channels:
+                    print("Warning! " + user_id + "did not resolve to any channels.")
                 for channel in channels:
                     output.write("https://www.youtube.com/channel/" + channel.id + "\n")
             else:

--- a/yt-comments.py
+++ b/yt-comments.py
@@ -39,7 +39,7 @@ def parse_args():
 
     parser.add_argument("--limit-comments", default=math.inf, type=int,
         help="limit the number of pages of comments return from each comment")
-    
+
     return parser.parse_args()
 
 def valid_path_arg(path):
@@ -85,14 +85,14 @@ if __name__ == "__main__":
         print("> Search channels")
         video_ids += get_videos_from_channels(args)
 
-    print("Number of vids: ", len(video_ids))
-
     if args.search_keywords:
         print("> Searching keywords")
         video_ids += get_videos_from_keywords(args)
 
+    print("> Number of videos found:", len(video_ids))
+
     print("> Retrieving comments")
-    comments = comments_from_videos(video_ids)
+    comments = comments_from_videos(video_ids, args)
 
     print("> Writing comments")
     write_objects_to_csv(list(comments), args.comments_output)

--- a/yt-comments.py
+++ b/yt-comments.py
@@ -37,6 +37,9 @@ def parse_args():
     parser.add_argument("--limit", default=math.inf, type=int,
         help="limit number of pages of videos returned from each search")
 
+    parser.add_argument("--limit-comments", default=math.inf, type=int,
+        help="limit the number of pages of comments return from each comment")
+    
     return parser.parse_args()
 
 def valid_path_arg(path):
@@ -57,10 +60,10 @@ def get_videos_from_keywords(args):
     for video in client.search_by_keyword(keywords, limit=args.limit, order=args.order, since=args.since):
         yield video
 
-def comments_from_videos(videos):
+def comments_from_videos(videos, args):
     for video in videos:
         try:
-            for comment in client.get_comments(video):
+            for comment in client.get_comments(video, limit=args.limit_comments):
                 yield comment
         except HttpError as e:
             print(e)

--- a/yt-comments.py
+++ b/yt-comments.py
@@ -52,6 +52,8 @@ def read_file_args(path):
 
 def get_videos_from_channels(args):
     for channel in read_file_args(args.search_channels):
+        if "/" in channel:
+            channel = channel.rsplit("/", 1)[1]
         for video in client.search_by_channel(channel, since=args.since, limit=args.limit, order=args.order):
             yield video
 

--- a/yt-comments.py
+++ b/yt-comments.py
@@ -1,0 +1,114 @@
+from api import *
+import auth
+import math
+import os
+from googleapiclient.errors import HttpError
+from pathlib import Path
+import argparse
+
+
+client = YoutubeClient(auth.credentials)
+
+def parse_args():
+    '''Set up command line argument parsing'''
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument("-c", "--search-channels", type=valid_path_arg,
+        help="path to file of channel ID per line")
+
+    parser.add_argument("-k", "--search-keywords", type=valid_path_arg,
+    	help="path to file of keyword per line")
+
+    parser.add_argument("-v", "--search-videos", type=valid_path_arg,
+        help="path to file of video ID per line")
+
+    parser.add_argument("--comments-output", type=valid_path_arg, default="comments.csv",
+    	help="path to comments output")
+
+    parser.add_argument("--video-output", type=valid_path_arg, default="videos.csv",
+        help="path to videos output")
+
+    parser.add_argument("--since", default="01/01/2019",
+        help="do not search before this date (DD/MM/YYYY)")
+
+    parser.add_argument("--order", default="viewCount",
+        help="order in which to return IDs")
+
+    parser.add_argument("--limit", default=math.inf, type=int,
+        help="limit number of pages of videos returned from each search")
+
+    return parser.parse_args()
+
+def valid_path_arg(path):
+    return Path(path)
+
+def read_file_args(path):
+    with path.open() as argfile:
+        for line in argfile:
+            yield line.strip()
+
+def get_videos_from_channels(args):
+    for channel in read_file_args(args.search_channels):
+        for video in client.search_by_channel(channel, since=args.since, limit=args.limit, order=args.order):
+            yield video
+
+def get_videos_from_keywords(args):
+    keywords = " ".join(read_file_args(args.search_keywords))
+    for video in client.search_by_keyword(keywords, limit=args.limit, order=args.order, since=args.since):
+        yield video
+
+def comments_from_videos(videos):
+    for video in videos:
+        try:
+            for comment in client.get_comments(video):
+                yield comment
+        except HttpError as e:
+            print(e)
+
+if __name__ == "__main__":
+    # Get program arguments
+    args = parse_args()
+
+    for arg in vars(args):
+        print (arg, getattr(args, arg))
+
+    video_ids = []
+
+    if args.search_videos:
+        print("> Reading video IDs")
+        video_ids += read_file_args(args.search_videos)
+
+    if args.search_channels:
+        print("> Search channels")
+        video_ids += get_videos_from_channels(args)
+
+    print("Number of vids: ", len(video_ids))
+
+    if args.search_keywords:
+        print("> Searching keywords")
+        video_ids += get_videos_from_keywords(args)
+
+    print("> Retrieving comments")
+    comments = comments_from_videos(video_ids)
+
+    print("> Writing comments")
+    write_objects_to_csv(list(comments), args.comments_output)
+
+    print("> Retrieving video meta")
+    video_queries = assemble_query(video_ids, existing=args.video_output)
+    videos = []
+    for q in video_queries:
+        try:
+            videos += client.get_videos(q)
+        except HttpError as e:
+            print(e)
+
+    print("> Writing videos")
+    write_objects_to_csv(list(videos), args.video_output)
+
+    print("> Done")
+
+
+
+
+


### PR DESCRIPTION
- Added a `search_by_channel` function for finding videos on a channel, rather than just by ID or keyword
- Added `yt-comments.py` which is a command line interface for collecting data (renamed main.py to api.py for clarity with this). E.g.:

```bash
python yt-comments.py --search-keywords keywords.txt --search-channels channels.txt --limit 10 --since 01/01/2020
```

The above gets all comments on videos that match the keywords in `keywords.txt` or appear on the channels listed in `channels.txt` (where both searches are limited to 10 pages and videos uploaded since 01/01/2020)

Or you can read in a file of mixed channels and user links, and resolve them all to only channel links:

```python yt-comments.py --convert-users links.txt```

Creates a file `links.converted.txt` with all the user links or raw user IDs converted to the one or more channels found for that user. Warnings will be issued for ID/links that couldn't resolve.